### PR TITLE
Fixes issue with Vagrant not installing vagrant-triggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning][semantic-versioning].
 
 ## Unreleased
 
-There are currently no unreleased changes.
+### Fixed
+
+- Vagrant plugin `vagrant-triggers` not installed automatically [#1][1] ([mihalski][])
 
 ## [v0.0.1] (2017-10-14)
 
@@ -15,6 +17,8 @@ There are currently no unreleased changes.
 
 - Initial version, first release.
 
+[1]: https://github.com/hassio-addons/hassio-vagrant/issues/1
 [keep-a-changelog]: http://keepachangelog.com/en/1.0.0/
+[mihalski]: https://github.com/mihalski
 [semantic-versioning]: http://semver.org/spec/v2.0.0.html
 [v0.0.1]: https://github.com/hassio-addons/hassio-vagrant/tree/v0.0.1

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -68,11 +68,11 @@ module HassioCommunityAddons
       return if ::Vagrant.has_plugin?('vagrant-triggers')
 
       print "A required vagrant plugin is missing: vagrant-triggers\n"
-      confirm 'Shall I go ahead an install it?', true unless raise \
-        ::Vagrant::Errors::VagrantError.new, 'Required plugin missing.'
+      raise ::Vagrant::Errors::VagrantError.new, 'Required plugin missing.' \
+        unless confirm 'Shall I go ahead an install it?', true
 
-      system 'vagrant plugin install vagrant-triggers' unless raise \
-        ::Vagrant::Errors::VagrantError.new, 'Installation of plugin failed.'
+      raise ::Vagrant::Errors::VagrantError.new, 'Installation of failed' \
+        unless system 'vagrant plugin install vagrant-triggers'
 
       print "Restarting Vagrant to re-load plugin changes...\n"
       system 'vagrant ' + ARGV.join(' ')


### PR DESCRIPTION
# Proposed Changes

Fixes an issue where Vagrant is not triggering automatic installation of a required plugin dependency; `vagrant-triggers`

## Related Issues

#1 