### PR TITLE
Add new hassio requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ and this project adheres to [Semantic Versioning][semantic-versioning].
 
 ## Unreleased
 
-No unreleased changes yet.
+### Added
+
+- D-Bus to host system
+- Avahi to host system
 
 ## [v0.0.2] (2017-10-17)
 

--- a/provision.sh
+++ b/provision.sh
@@ -20,11 +20,13 @@ readonly DOCKER_DOWNLOAD="https://download.docker.com/linux"
 readonly NETDATA_INSTALLER="https://my-netdata.io/kickstart-static64.sh"
 readonly APT_REQUIREMENTS=(
     apt-transport-https
+    avahi-daemon
     ca-certificates
     curl
-    software-properties-common
-    socat
+    dbus
     jq
+    socat
+    software-properties-common
 )
 
 # ==============================================================================


### PR DESCRIPTION
# Proposed Changes

The Hass.io generic Linux installer now requires D-Bus & Avahi daemons to be installed.
This PR ensures those requirements in the host OS.

## Related Issues

None