### PR TITLE
[WIP] Hyper-V and change to Bento

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -96,6 +96,7 @@ module HassioCommunityAddons
         machine_config machine
         machine_provider_virtualbox machine
         machine_provider_vmware machine
+        machine_provider_hyperv machine
         machine_shares machine
         machine_provision machine
         machine_cleanup_on_destroy machine
@@ -137,6 +138,19 @@ module HassioCommunityAddons
           vmw.vmx['memsize'] = @config['memory']
           vmw.vmx['numvcpus'] = @config['cpus']
         end
+      end
+    end
+
+    # Configures the HyperV provider
+    #
+    # @param [Vagrant::Config::V2::Root] machine Vagrant VM root config
+    def machine_provider_hyperv(machine)
+      machine.vm.provider :hyperv do |hyperv|
+        hyperv.vmname = @config['hostname']
+        hyperv.memory = @config['memory']
+        hyperv.cpus = @config['cpus']
+        hyperv.enable_virtualization_extensions = true
+        hyperv.differencing_disk = true
       end
     end
 

--- a/configuration.yml
+++ b/configuration.yml
@@ -3,7 +3,7 @@ memory: 2048
 cpus: 2
 hostname: hassio
 post_up_message: Hass.io starting... wait a couple of minutes!
-box: ubuntu/xenial64
+box: bento/ubuntu-16.04
 shares:
   addons: /usr/share/hassio/addons/local
   backup: /usr/share/hassio/backup

--- a/provision.sh
+++ b/provision.sh
@@ -136,12 +136,12 @@ install_hassio() {
 show_post_up_message() {
     local ip_addresses
     ip_addresses=()
-    for available_interface in `ls /sys/class/net`; do
-        if [[ "$available_interface" != "lo" ]] &&
-           [[ "$available_interface" != "docker0" ]] &&
-           [[ "$available_interface" != "hassio" ]]
+    for i in $(basename -a /sys/class/net/*); do
+        if [[ "$i" != "lo" ]] &&
+           [[ "$i" != "docker0" ]] &&
+           [[ "$i" != "hassio" ]]
         then
-            ip_addresses+=($(ip -f inet -o addr show ${available_interface} | cut -d\  -f 7 | cut -d/ -f 1))
+            ip_addresses+=($(ip -f inet -o addr show "${i}" | cut -d\  -f 7 | cut -d/ -f 1))
         fi
     done
 
@@ -152,16 +152,13 @@ show_post_up_message() {
     echo ' before it is actually responding/available.'
     echo ''
     echo ' Home Assitant is running on the following links:'
-    for i in ${ip_addresses[@]}; do
-    echo "  - http://${i}:8123"; done
+    for i in "${ip_addresses[@]}"; do echo "  - http://${i}:8123" ; done
     echo ''
     echo ' Portainer is running on the following links:'
-    for i in ${ip_addresses[@]}; do
-    echo "  - http://${i}:9000"; done
+    for i in "${ip_addresses[@]}"; do echo "  - http://${i}:9000" ; done
     echo ''
     echo ' Netdata is providing awesome stats on these links:'
-    for i in ${ip_addresses[@]}; do
-    echo "  - http://${i}:19999"; done
+    for i in "${ip_addresses[@]}"; do echo "  - http://${i}:19999" ; done
     echo '====================================================================='
 }
 

--- a/provision.sh
+++ b/provision.sh
@@ -137,8 +137,9 @@ show_post_up_message() {
     local ip_public
     local ip_private
     
-    ip_public=$(ip -f inet -o addr show enp0s8 | cut -d\  -f 7 | cut -d/ -f 1)
-    ip_private=$(ip -f inet -o addr show enp0s9 | cut -d\  -f 7 | cut -d/ -f 1)
+    sleep 5
+    ip_public=$(ip -f inet -o addr show eth0 | cut -d\  -f 7 | cut -d/ -f 1)
+    ip_private=$(ip -f inet -o addr show hassio | cut -d\  -f 7 | cut -d/ -f 1)
 
     echo '====================================================================='
     echo ' Community Hass.io Add-ons: Vagrant'

--- a/provision.sh
+++ b/provision.sh
@@ -69,7 +69,7 @@ install_docker() {
     apt-get update
     apt-get install -y docker-ce
 
-    usermod -aG docker ubuntu
+    usermod -aG docker vagrant
 }
 
 # ------------------------------------------------------------------------------

--- a/provision.sh
+++ b/provision.sh
@@ -138,8 +138,8 @@ show_post_up_message() {
     local ip_private
     
     sleep 5
-    ip_public=$(ip -f inet -o addr show eth0 | cut -d\  -f 7 | cut -d/ -f 1)
-    ip_private=$(ip -f inet -o addr show hassio | cut -d\  -f 7 | cut -d/ -f 1)
+    ip_public=$(ip -f inet -o addr show eth1 | cut -d\  -f 7 | cut -d/ -f 1)
+    ip_private=$(ip -f inet -o addr show eth2 | cut -d\  -f 7 | cut -d/ -f 1)
 
     echo '====================================================================='
     echo ' Community Hass.io Add-ons: Vagrant'

--- a/provision.sh
+++ b/provision.sh
@@ -134,12 +134,16 @@ install_hassio() {
 #   None
 # ------------------------------------------------------------------------------
 show_post_up_message() {
-    local ip_public
-    local ip_private
-    
-    sleep 5
-    ip_public=$(ip -f inet -o addr show eth1 | cut -d\  -f 7 | cut -d/ -f 1)
-    ip_private=$(ip -f inet -o addr show eth2 | cut -d\  -f 7 | cut -d/ -f 1)
+    local ip_addresses
+    ip_addresses=()
+    for available_interface in `ls /sys/class/net`; do
+        if [[ "$available_interface" != "lo" ]] &&
+           [[ "$available_interface" != "docker0" ]] &&
+           [[ "$available_interface" != "hassio" ]]
+        then
+            ip_addresses+=($(ip -f inet -o addr show ${available_interface} | cut -d\  -f 7 | cut -d/ -f 1))
+        fi
+    done
 
     echo '====================================================================='
     echo ' Community Hass.io Add-ons: Vagrant'
@@ -148,16 +152,16 @@ show_post_up_message() {
     echo ' before it is actually responding/available.'
     echo ''
     echo ' Home Assitant is running on the following links:'
-    echo "  - http://${ip_private}:8123"
-    echo "  - http://${ip_public}:8123"
+    for i in ${ip_addresses[@]}; do
+    echo "  - http://${i}:8123"; done
     echo ''
     echo ' Portainer is running on the following links:'
-    echo "  - http://${ip_private}:9000"
-    echo "  - http://${ip_public}:9000"
+    for i in ${ip_addresses[@]}; do
+    echo "  - http://${i}:9000"; done
     echo ''
     echo ' Netdata is providing awesome stats on these links:'
-    echo "  - http://${ip_private}:19999"
-    echo "  - http://${ip_public}:19999"
+    for i in ${ip_addresses[@]}; do
+    echo "  - http://${i}:19999"; done
     echo '====================================================================='
 }
 


### PR DESCRIPTION
# Proposed Changes

In a Windows install, running Docker in Windows requires Hyper-V enabled. Running VirtualBox, on the other hand, requires Hyper-V to be disabled. As Vagrant supports Hyper-V as a provider, it would be nice to enable this.

I've started with the work, but it is not ready yet (thus the [WIP] tag, I hope that's correct). The main changes are:
- Change of box from `ubuntu/xenial64` to `bento/ubuntu-16.04`
  - `ubuntu/xenial64` does not support hyper-v, so it would be necessary to change base box. `bento` boxes should not be that different, and are even referenced in the [official documentation](https://www.vagrantup.com/docs/boxes.html).
  - One difference is the default username, which will be changed from `ubuntu` to `vagrant`. On the other hand, this seems to be the recommended [default for Vagrant](https://www.vagrantup.com/docs/boxes/base.html).
- Change of network interface name in `provision.sh` script
  - The network interfaces are no longer named `enp0s8` and `enp0s9`. I believe the new names are `eth0` and `hassio`, but need to test this more.
  - Hyper-V does not manage networks exactly the same way as other providers, so testing will be required to make sure that part works as intended.

## Related Issues

[#7] Issue I created before making the pull request.