### PR TITLE
:hammer: Rewrites onto Vagrant's native triggers

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,10 +68,9 @@ those tools.
 ## Getting started
 
 Before launching your Hass.io environment, you must install
-[VirtualBox][virtualbox] 5.1 or higher, as well as [Vagrant][vagrant] 1.9.0 or
+[VirtualBox][virtualbox] 5.1 or higher, as well as [Vagrant][vagrant] 2.1.0 or
 higher. These software packages provide easy-to-use visual installers for
-all popular operating systems and are open source. We also require a Vagrant
-plugin; `vagrant-triggers`, which is installed automatically on first use.
+all popular operating systems and are open source.
 
 Once [VirtualBox][virtualbox] and [Vagrant][vagrant] have been installed, you
 install `hassio-vagrant` by simply cloning this repository. Consider cloning

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -156,10 +156,8 @@ module HassioCommunityAddons
         trigger.name = 'Cleanup'
         trigger.info = 'Cleaning up Home Assistant configuration'
         trigger.run = {
-          inline: "find '#{config_directory}'" \
-            " -mindepth 1 -maxdepth 1" \
-            " -not -name '.gitkeep'" \
-            " -exec rm -rf {} \\;"
+          inline: "find '#{config_directory}' -mindepth 1 -maxdepth 1" \
+            ' -not -name ".gitkeep" -exec rm -rf {} \;'
         }
       end
     end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -154,9 +154,12 @@ module HassioCommunityAddons
       config_directory = File.join(File.dirname(__FILE__), 'config')
       machine.trigger.after :destroy do |trigger|
         trigger.name = 'Cleanup'
-        trigger.info = 'Cleaning up Home Assistant configuration';
-        trigger.run = { 
-          inline: "find '#{config_directory}' -mindepth 1 -maxdepth 1 -not -name '.gitkeep' -exec rm -rf {} \\;"
+        trigger.info = 'Cleaning up Home Assistant configuration'
+        trigger.run = {
+          inline: "find '#{config_directory}'" \
+            " -mindepth 1 -maxdepth 1" \
+            " -not -name '.gitkeep'" \
+            " -exec rm -rf {} \\;"
         }
       end
     end


### PR DESCRIPTION
Rewrites the current use of a Vagrant triggers plugin, onto
the native trigger support (since Vagrant 2.1.0). Also up the
version requirement because of this.

## Related Issues

Closes #11