### PR TITLE
✨ Adds option to keep HA config on destroy

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -86,7 +86,7 @@ module HassioCommunityAddons
         machine_provider_virtualbox machine
         machine_shares machine
         machine_provision machine
-        machine_cleanup_on_destroy machine
+        machine_cleanup_on_destroy machine unless @config['keep_config']
       end
     end
 

--- a/configuration.yml
+++ b/configuration.yml
@@ -4,6 +4,7 @@ cpus: 2
 hostname: hassio
 post_up_message: Hass.io starting... wait a couple of minutes!
 box: ubuntu/bionic64
+keep_config: false
 shares:
   addons: /usr/share/hassio/addons/local
   backup: /usr/share/hassio/backup


### PR DESCRIPTION
# Proposed Changes

> This adds the `keep_config` option in the Vagrant `configuration.yml` to keep the config when destroying the Vagrant box. *Default is set to **false**.*

## Related Issues

> N/A