### PR TITLE
✨ Adds option to set default bridge interface

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -96,7 +96,11 @@ module HassioCommunityAddons
     def machine_config(machine)
       machine.vm.hostname = @config['hostname']
       machine.vm.network 'private_network', type: 'dhcp'
-      machine.vm.network 'public_network', type: 'dhcp'
+      machine.vm.network(
+        'public_network',
+        type: 'dhcp',
+        bridge: @config['bridge']
+      )
     end
 
     # Configures the Virtualbox provider

--- a/configuration.yml
+++ b/configuration.yml
@@ -4,6 +4,7 @@ cpus: 2
 hostname: hassio
 post_up_message: Hass.io starting... wait a couple of minutes!
 box: ubuntu/bionic64
+bridge: ~
 shares:
   addons: /usr/share/hassio/addons/local
   backup: /usr/share/hassio/backup


### PR DESCRIPTION
# Proposed Changes

> This adds the `bridge` option in the Vagrant `configuration.yml` to select which network interface to use for the bridge on the Vagrant box.

**Examples:**

```yaml
bridge: "en0: Wi-Fi (AirPort)"
```

```yaml
bridge:
  - "en0: Wi-Fi (AirPort)"
  - "en1: Wi-Fi (AirPort)"
```

## Related Issues

> N/A