### PR TITLE
Adding logic for audio based on OS

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -33,24 +33,6 @@ require 'yaml'
 require 'pp'
 
 ::Vagrant.require_version '>= 2.1.0'
-# Identify OS Platform
-module OS
-  def self.windows?
-    (/cygwin|mswin|mingw|bccwin|wince|emx/ =~ RUBY_PLATFORM) != nil
-  end
-
-  def self.mac?
-    (/darwin/ =~ RUBY_PLATFORM) != nil
-  end
-
-  def self.unix?
-    !OS.windows?
-  end
-
-  def self.linux?
-    OS.unix? && !OS.mac?
-  end
-end
 
 module HassioCommunityAddons
   # Manages the Vagrant configuration
@@ -136,17 +118,10 @@ module HassioCommunityAddons
         vbox.customize ['modifyvm', :id, '--natdnshostresolver1', 'on']
         vbox.customize ['modifyvm', :id, '--natdnsproxy1', 'on']
         vbox.customize ['modifyvm', :id, '--usb', 'on', '--usbehci', 'on']
-        if OS.windows?
-          vbox.customize ['modifyvm', :id, '--audio', 'dsound',
-                          '--audiocontroller', 'hda',
-                          '--audioin', 'on', '--audioout', 'on']
-        elsif OS.mac?
-          vbox.customize ['modifyvm', :id, '--audio', 'coreaudio',
-                          '--audiocontroller', 'hda',
-                          '--audioin', 'on', '--audioout', 'on']
-          # else
-          # someone needs to add other os commands
-        end
+        soundtype = ::Vagrant::Util::Platform.windows? ? 'dsound' : 'coreaudio'
+        vbox.customize ['modifyvm', :id, '--audio', soundtype,
+                        '--audiocontroller', 'hda',
+                        '--audioin', 'on', '--audioout', 'on']
       end
     end
     # rubocop:enable Metrics/MethodLength

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -33,23 +33,23 @@ require 'yaml'
 require 'pp'
 
 ::Vagrant.require_version '>= 2.1.0'
-
+# Identify OS Platform
 module OS
-    def OS.windows?
-        (/cygwin|mswin|mingw|bccwin|wince|emx/ =~ RUBY_PLATFORM) != nil
-    end
+  def OS.windows?
+    (/cygwin|mswin|mingw|bccwin|wince|emx/ =~ RUBY_PLATFORM) != nil
+  end
 
-    def OS.mac?
-        (/darwin/ =~ RUBY_PLATFORM) != nil
-    end
+  def OS.mac?
+    (/darwin/ =~ RUBY_PLATFORM) != nil
+  end
 
-    def OS.unix?
-        !OS.windows?
-    end
+  def OS.unix?
+    !OS.windows?
+  end
 
-    def OS.linux?
-        OS.unix? and not OS.mac?
-    end
+  def OS.linux?
+    OS.unix? && !OS.mac?
+  end
 end
 
 module HassioCommunityAddons
@@ -126,33 +126,32 @@ module HassioCommunityAddons
     # @param [Vagrant::Config::V2::Root] machine Vagrant VM root config
     # rubocop:disable Metrics/MethodLength
     def machine_provider_virtualbox(machine)
-		machine.vm.provider :virtualbox do |vbox|
-	      vbox.name = @config['hostname']
-		  vbox.cpus = @config['cpus']
-		  vbox.customize ['modifyvm', :id, '--memory', @config['memory']]
-		  vbox.customize ['modifyvm', :id, '--nictype1', 'virtio']
-		  vbox.customize ['modifyvm', :id, '--nictype2', 'virtio']
-		  vbox.customize ['modifyvm', :id, '--nictype3', 'virtio']
-		  vbox.customize ['modifyvm', :id, '--natdnshostresolver1', 'on']
-		  vbox.customize ['modifyvm', :id, '--natdnsproxy1', 'on']
-		  vbox.customize ['modifyvm', :id, '--usb', 'on', '--usbehci', 'on']
-			if OS.windows?
-				vbox.customize ['modifyvm', :id, '--audio', 'dsound',
-				  '--audiocontroller', 'hda',
-          '--audioin', 'on',
-					'--audioout', 'on']
-			elsif OS.mac?
-				vbox.customize ['modifyvm', :id, '--audio', 'coreaudio',
-					'--audiocontroller', 'hda',
-          '--audioin', 'on',
-					'--audioout', 'on']
-			else
-					# someone needs to add other os commands
-			end
-		end
-	end
+      machine.vm.provider :virtualbox do |vbox|
+          vbox.name = @config['hostname']
+          vbox.cpus = @config['cpus']
+          vbox.customize ['modifyvm', :id, '--memory', @config['memory']]
+          vbox.customize ['modifyvm', :id, '--nictype1', 'virtio']
+          vbox.customize ['modifyvm', :id, '--nictype2', 'virtio']
+          vbox.customize ['modifyvm', :id, '--nictype3', 'virtio']
+          vbox.customize ['modifyvm', :id, '--natdnshostresolver1', 'on']
+          vbox.customize ['modifyvm', :id, '--natdnsproxy1', 'on']
+          vbox.customize ['modifyvm', :id, '--usb', 'on', '--usbehci', 'on']
+          if OS.windows?
+            vbox.customize ['modifyvm', :id, '--audio', 'dsound',
+                            '--audiocontroller', 'hda',
+                            '--audioin', 'on',
+                            '--audioout', 'on']
+          elsif OS.mac?
+            vbox.customize ['modifyvm', :id, '--audio', 'coreaudio',
+                            '--audiocontroller', 'hda',
+                            '--audioin', 'on',
+                            '--audioout', 'on']
+          else
+            # someone needs to add other os commands
+          end
+      end
+    end
     # rubocop:enable Metrics/MethodLength
-
     # Configures a VM's shares
     #
     # @param [Vagrant::Config::V2::Root] machine Vagrant VM root config

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -35,19 +35,19 @@ require 'pp'
 ::Vagrant.require_version '>= 2.1.0'
 # Identify OS Platform
 module OS
-  def OS.windows?
+  def self.windows?
     (/cygwin|mswin|mingw|bccwin|wince|emx/ =~ RUBY_PLATFORM) != nil
   end
 
-  def OS.mac?
+  def self.mac?
     (/darwin/ =~ RUBY_PLATFORM) != nil
   end
 
-  def OS.unix?
+  def self.unix?
     !OS.windows?
   end
 
-  def OS.linux?
+  def self.linux?
     OS.unix? && !OS.mac?
   end
 end
@@ -127,34 +127,33 @@ module HassioCommunityAddons
     # rubocop:disable Metrics/MethodLength
     def machine_provider_virtualbox(machine)
       machine.vm.provider :virtualbox do |vbox|
-          vbox.name = @config['hostname']
-          vbox.cpus = @config['cpus']
-          vbox.customize ['modifyvm', :id, '--memory', @config['memory']]
-          vbox.customize ['modifyvm', :id, '--nictype1', 'virtio']
-          vbox.customize ['modifyvm', :id, '--nictype2', 'virtio']
-          vbox.customize ['modifyvm', :id, '--nictype3', 'virtio']
-          vbox.customize ['modifyvm', :id, '--natdnshostresolver1', 'on']
-          vbox.customize ['modifyvm', :id, '--natdnsproxy1', 'on']
-          vbox.customize ['modifyvm', :id, '--usb', 'on', '--usbehci', 'on']
-          if OS.windows?
-            vbox.customize ['modifyvm', :id, '--audio', 'dsound',
-                            '--audiocontroller', 'hda',
-                            '--audioin', 'on',
-                            '--audioout', 'on']
-          elsif OS.mac?
-            vbox.customize ['modifyvm', :id, '--audio', 'coreaudio',
-                            '--audiocontroller', 'hda',
-                            '--audioin', 'on',
-                            '--audioout', 'on']
-          else
-            # someone needs to add other os commands
-          end
+        vbox.name = @config['hostname']
+        vbox.cpus = @config['cpus']
+        vbox.customize ['modifyvm', :id, '--memory', @config['memory']]
+        vbox.customize ['modifyvm', :id, '--nictype1', 'virtio']
+        vbox.customize ['modifyvm', :id, '--nictype2', 'virtio']
+        vbox.customize ['modifyvm', :id, '--nictype3', 'virtio']
+        vbox.customize ['modifyvm', :id, '--natdnshostresolver1', 'on']
+        vbox.customize ['modifyvm', :id, '--natdnsproxy1', 'on']
+        vbox.customize ['modifyvm', :id, '--usb', 'on', '--usbehci', 'on']
+        if OS.windows?
+          vbox.customize ['modifyvm', :id, '--audio', 'dsound',
+                          '--audiocontroller', 'hda',
+                          '--audioin', 'on', '--audioout', 'on']
+        elsif OS.mac?
+          vbox.customize ['modifyvm', :id, '--audio', 'coreaudio',
+                          '--audiocontroller', 'hda',
+                          '--audioin', 'on', '--audioout', 'on']
+          # else
+          # someone needs to add other os commands
+        end
       end
     end
     # rubocop:enable Metrics/MethodLength
     # Configures a VM's shares
     #
     # @param [Vagrant::Config::V2::Root] machine Vagrant VM root config
+
     def machine_shares(machine)
       @config['shares'].each do |src, dst|
         machine.vm.synced_folder(

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -138,14 +138,16 @@ module HassioCommunityAddons
 		  vbox.customize ['modifyvm', :id, '--usb', 'on', '--usbehci', 'on']
 			if OS.windows?
 				vbox.customize ['modifyvm', :id, '--audio', 'dsound',
-					'--audiocontroller', 'hda', '--audioin', 'on',
+				  '--audiocontroller', 'hda',
+          '--audioin', 'on',
 					'--audioout', 'on']
 			elsif OS.mac?
 				vbox.customize ['modifyvm', :id, '--audio', 'coreaudio',
-					'--audiocontroller', 'hda', '--audioin', 'on',
+					'--audiocontroller', 'hda',
+          '--audioin', 'on',
 					'--audioout', 'on']
 			else
-					#someone needs to add other os commands
+					# someone needs to add other os commands
 			end
 		end
 	end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -34,6 +34,24 @@ require 'pp'
 
 ::Vagrant.require_version '>= 2.1.0'
 
+module OS
+    def OS.windows?
+        (/cygwin|mswin|mingw|bccwin|wince|emx/ =~ RUBY_PLATFORM) != nil
+    end
+
+    def OS.mac?
+        (/darwin/ =~ RUBY_PLATFORM) != nil
+    end
+
+    def OS.unix?
+        !OS.windows?
+    end
+
+    def OS.linux?
+        OS.unix? and not OS.mac?
+    end
+end
+
 module HassioCommunityAddons
   # Manages the Vagrant configuration
   # @author Franck Nijhof <frenck@addons.community>
@@ -108,21 +126,29 @@ module HassioCommunityAddons
     # @param [Vagrant::Config::V2::Root] machine Vagrant VM root config
     # rubocop:disable Metrics/MethodLength
     def machine_provider_virtualbox(machine)
-      machine.vm.provider :virtualbox do |vbox|
-        vbox.name = @config['hostname']
-        vbox.cpus = @config['cpus']
-        vbox.customize ['modifyvm', :id, '--memory', @config['memory']]
-        vbox.customize ['modifyvm', :id, '--nictype1', 'virtio']
-        vbox.customize ['modifyvm', :id, '--nictype2', 'virtio']
-        vbox.customize ['modifyvm', :id, '--nictype3', 'virtio']
-        vbox.customize ['modifyvm', :id, '--natdnshostresolver1', 'on']
-        vbox.customize ['modifyvm', :id, '--natdnsproxy1', 'on']
-        vbox.customize ['modifyvm', :id, '--usb', 'on', '--usbehci', 'on']
-        vbox.customize ['modifyvm', :id, '--audio', 'coreaudio',
-                        '--audiocontroller', 'hda', '--audioin', 'on',
-                        '--audioout', 'on']
-      end
-    end
+		machine.vm.provider :virtualbox do |vbox|
+	      vbox.name = @config['hostname']
+		  vbox.cpus = @config['cpus']
+		  vbox.customize ['modifyvm', :id, '--memory', @config['memory']]
+		  vbox.customize ['modifyvm', :id, '--nictype1', 'virtio']
+		  vbox.customize ['modifyvm', :id, '--nictype2', 'virtio']
+		  vbox.customize ['modifyvm', :id, '--nictype3', 'virtio']
+		  vbox.customize ['modifyvm', :id, '--natdnshostresolver1', 'on']
+		  vbox.customize ['modifyvm', :id, '--natdnsproxy1', 'on']
+		  vbox.customize ['modifyvm', :id, '--usb', 'on', '--usbehci', 'on']
+			if OS.windows?
+				vbox.customize ['modifyvm', :id, '--audio', 'dsound',
+					'--audiocontroller', 'hda', '--audioin', 'on',
+					'--audioout', 'on']
+			elsif OS.mac?
+				vbox.customize ['modifyvm', :id, '--audio', 'coreaudio',
+					'--audiocontroller', 'hda', '--audioin', 'on',
+					'--audioout', 'on']
+			else
+					#someone needs to add other os commands
+			end
+		end
+	end
     # rubocop:enable Metrics/MethodLength
 
     # Configures a VM's shares


### PR DESCRIPTION
# Proposed Changes

Adding logic for Windows/Mac audio devices.

Needs validating on a Mac, have not added Linux devices, appears to works under Windows 10 (was a stackoverflow answer for the Ruby OS detection! :) , though not sure the linux if will ever fire)

## Related Issues

https://github.com/hassio-addons/hassio-vagrant/issues/23

[autolink-references]: https://github.com/hassio-addons/hassio-vagrant/issues/23