### PR TITLE
fixed install script location to avoid deprec statement

### DIFF
--- a/provision.sh
+++ b/provision.sh
@@ -15,7 +15,7 @@ set -o pipefail # Return exit status of the last command in the pipe that failed
 # GLOBALS
 # ==============================================================================
 readonly EX_OK=0
-readonly HASSIO_INSTALLER="https://raw.githubusercontent.com/home-assistant/supervised-installer/master/installer.sh"
+readonly HASSIO_INSTALLER="https://raw.githubusercontent.com/home-assistant/supervised-installer/1f30d124ef7d0ee84b45d1772cb5c1e4a94c67b8/installer.sh"
 readonly DOCKER_DOWNLOAD="https://download.docker.com/linux"
 readonly APT_REQUIREMENTS=(
     apparmor-utils


### PR DESCRIPTION
# Proposed Changes

due to the deprec annoucement to discontinue linux support, the official script is not working anymore. See issue and solution proposed here:
https://community.home-assistant.io/t/installing-deprecated-hassio-on-ubuntu-18-04/194796/24

## Related Issues

none


<blockquote><img src="https://community-home-assistant-assets.s3.dualstack.us-west-2.amazonaws.com/original/3X/8/0/80d3f33958a234aab5cb9364b998048064d12b9d.png" width="48" align="right"><div><img src="https://community-home-assistant-assets.s3.dualstack.us-west-2.amazonaws.com/optimized/3X/f/4/f42b82971fce994297fbc2b269efa248beef897b_2_32x32.png" height="14"> Home Assistant Community</div><div><strong><a href="https://community.home-assistant.io/t/installing-deprecated-hassio-on-ubuntu-18-04/194796/24">Installing (deprecated) hassio on Ubuntu 18.04</a></strong></div><div>I support your advice.  Adjusting the installer script is like an entrance test. If you fail it then you probably need to study some more or choose something else.  In the recent blog post, I was quite surprised by the number of people asking what they had installed and were they affected by the deprecation. I wouldn’t think it was possible for someone to not know what they installed, but I was proven wrong.</div></blockquote>